### PR TITLE
Fixes #89 - LRS not filtering on actor

### DIFF
--- a/lrs/tests/AuthTests.py
+++ b/lrs/tests/AuthTests.py
@@ -514,8 +514,8 @@ class AuthTests(TestCase):
         self.assertEqual(actorObjectGetResponse.status_code, 200)
         stmts = json.loads(actorObjectGetResponse.content)
         dbstmts = models.statement.objects.all()
-        # Will return 10 since that is server limit
-        self.assertEqual(len(stmts["statements"]), 10)
+
+        self.assertEqual(len(stmts["statements"]), 0)
 
     def test_verb_filter(self):
         param = {"verb":"http://adlnet.gov/expapi/verbs/missed"}

--- a/lrs/util/retrieve_statement.py
+++ b/lrs/util/retrieve_statement.py
@@ -158,6 +158,8 @@ def complex_get(req_dict):
         obj = parse_incoming_object(objectData, args)
         if obj:
             args['stmt_object'] = obj
+        else:
+            return []
 
     # If searching by verb
     if 'verb' in the_dict:
@@ -165,19 +167,26 @@ def complex_get(req_dict):
         verb = models.Verb.objects.filter(verb_id=verb_id)
         if verb:
             args['verb'] = verb
+        else:
+            return []
 
     # If searching by registration
     if 'registration' in the_dict:
         uuid = str(the_dict['registration'])
         cntx = models.context.objects.filter(registration=uuid)
-        args['context'] = cntx
-    
+        if cntx:
+            args['context'] = cntx
+        else:
+            return []
+
     # If searching by actor
     if 'actor' in the_dict:
         actorData = the_dict['actor']
         actor = parse_incoming_actor(actorData)
         if actor:
             args['actor'] = actor
+        else:
+            return []
 
     # If searching by instructor
     if 'instructor' in the_dict:
@@ -185,8 +194,10 @@ def complex_get(req_dict):
         inst = parse_incoming_instructor(instData)
         if inst:
             args['context__in'] = inst
-    
-    # there's a default of true
+        else:
+            return []
+
+    # there's a default of true - ALWAYS GETS SET
     if not 'authoritative' in the_dict or str(the_dict['authoritative']).upper() == 'TRUE':
         args['authoritative'] = True   
 


### PR DESCRIPTION
Should not return any statements when querying with un-found actor/object/verb/context/instructor
