### PR TITLE
Build was failing with this message on Ubuntu 12.10:

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ pycrypto==2.5
 lxml==2.3.4
 django-extensions==1.1.1
 South==0.8.1
-jsonfield==0.9.17
+jsonfield==0.9.19


### PR DESCRIPTION
  File "~/dev/env/local/lib/python2.7/site-packages/jsonfield/fields.py", line 50, in <module>
    class JSONFieldBase(six.with_metaclass(SubfieldBase, base=models.Field)):
TypeError: with_metaclass() got an unexpected keyword argument 'base'
