### PR TITLE
Webhooks

### DIFF
--- a/adl_lrs/settings.py
+++ b/adl_lrs/settings.py
@@ -133,8 +133,8 @@ CELERY_RESULT_SERIALIZER = 'json'
 
 # Limit on number of statements the server will return
 SERVER_STMT_LIMIT = 100
-# One minute timeout to all celery tasks
-CELERYD_TASK_TIME_LIMIT = 20
+# Fifteen second timeout to all celery tasks
+CELERYD_TASK_SOFT_TIME_LIMIT = 15
 # ActivityID resolve timeout (seconds)
 ACTIVITY_ID_RESOLVE_TIMEOUT = .2
 # Caches for /more endpoint and attachments

--- a/adl_lrs/templates/my_statements_holder.html
+++ b/adl_lrs/templates/my_statements_holder.html
@@ -9,7 +9,7 @@
                 <h5 class="email-subject">{{ stmt.timestamp }}</h5>
                 <h5 class="email-subject">{{ stmt.statement_id }}</h5>
                 <p class="email-desc">
-                    <pre id="stmt" class="jsonpre">{{ stmt.full_statement|jsonify }}</pre>
+                    <pre id="stmt" class="jsonpre">{{ stmt.to_dict|jsonify }}</pre>
                 </p>
             </div>
             <br>

--- a/adl_lrs/views.py
+++ b/adl_lrs/views.py
@@ -183,7 +183,6 @@ def reg_client2(request):
 @require_http_methods(["GET"])
 def my_statements(request, template="my_statements.html", page_template="my_statements_holder.html"):
     context = {'statements': Statement.objects.filter(user=request.user).order_by('-timestamp'),'page_template': page_template}
-    
     if request.is_ajax():
         template = page_template
     return render_to_response(template, context, context_instance=RequestContext(request))

--- a/lrs/managers/ActivityManager.py
+++ b/lrs/managers/ActivityManager.py
@@ -57,21 +57,14 @@ class ActivityManager():
         try:
             act = Activity.objects.get(activity_id=activity_id)
         except Activity.DoesNotExist:
+            act_created = True
             if self.define_permission:
-                can_define = True
                 # If activity DNE and can define - create activity with auth
-                try:
-                    self.Activity, act_created = Activity.objects.get_or_create(activity_id=activity_id, authority=self.auth)       
-                except IntegrityError:
-                    self.Activity = Activity.objects.get(activity_id=activity_id, authority=self.auth)
-                    act_created = False
+                self.Activity = Activity.objects.create(activity_id=activity_id, authority=self.auth)
+                can_define = True
             else:
                 # If activity DNE and cannot define - create activity without auth
-                try:
-                    self.Activity, act_created = Activity.objects.get_or_create(activity_id=activity_id)
-                except IntegrityError:
-                    self.Activity = Activity.objects.get(activity_id=activity_id)
-                    act_created = False
+                self.Activity = Activity.objects.create(activity_id=activity_id)
         # activity already exists
         else:
             self.Activity = act

--- a/lrs/managers/ActivityManager.py
+++ b/lrs/managers/ActivityManager.py
@@ -57,14 +57,21 @@ class ActivityManager():
         try:
             act = Activity.objects.get(activity_id=activity_id)
         except Activity.DoesNotExist:
-            act_created = True
             if self.define_permission:
-                # If activity DNE and can define - create activity with auth
-                self.Activity = Activity.objects.create(activity_id=activity_id, authority=self.auth)
                 can_define = True
+                # If activity DNE and can define - create activity with auth
+                try:
+                    self.Activity, act_created = Activity.objects.get_or_create(activity_id=activity_id, authority=self.auth)       
+                except IntegrityError:
+                    self.Activity = Activity.objects.get(activity_id=activity_id, authority=self.auth)
+                    act_created = False
             else:
                 # If activity DNE and cannot define - create activity without auth
-                self.Activity = Activity.objects.create(activity_id=activity_id)
+                try:
+                    self.Activity, act_created = Activity.objects.get_or_create(activity_id=activity_id)
+                except IntegrityError:
+                    self.Activity = Activity.objects.get(activity_id=activity_id)
+                    act_created = False
         # activity already exists
         else:
             self.Activity = act
@@ -78,7 +85,7 @@ class ActivityManager():
                    (act.authority == self.auth) or \
                    (act.authority.objectType == 'Group' and self.auth in act.authority.member.all()) or \
                    (self.auth.objectType == 'Group' and act.authority in self.auth.member.all()):
-                    can_define = True                                                     
+                    can_define = True
                 else:
                     can_define = False
             # activity already exists but do not have define

--- a/lrs/utils/req_process.py
+++ b/lrs/utils/req_process.py
@@ -186,7 +186,7 @@ def statements_get(req_dict):
         else:
             st = Statement.objects.get(statement_id=req_dict['statementId'])
             
-            stmt_result = json.dumps(st.to_dict(format=req_dict['params']['format']))
+            stmt_result = json.dumps(st.to_dict(format=req_dict['params']['format']), sort_keys=False)
             resp = HttpResponse(stmt_result, content_type=mime_type, status=200)
             content_length = len(stmt_result)
     # Complex GET
@@ -372,7 +372,7 @@ def activity_profile_delete(req_dict):
 def activities_get(req_dict):
     activityId = req_dict['params']['activityId']
     act = Activity.objects.get(activity_id=activityId, authority__isnull=False)
-    return_act = json.dumps(act.to_dict('all'))    
+    return_act = json.dumps(act.to_dict('all'), sort_keys=False)    
     resp = HttpResponse(return_act, mimetype="application/json", status=200)
     resp['Content-Length'] = str(len(return_act))
     # If it's a HEAD request
@@ -436,7 +436,7 @@ def agent_profile_delete(req_dict):
 
 def agents_get(req_dict):
     a = Agent.objects.get(**req_dict['agent_ifp'])    
-    agent_data = json.dumps(a.to_dict_person())
+    agent_data = json.dumps(a.to_dict_person(), sort_keys=False)
     resp = HttpResponse(agent_data, mimetype="application/json")
     resp['Content-Length'] = str(len(agent_data))
     # If it's a HEAD request

--- a/lrs/utils/retrieve_statement.py
+++ b/lrs/utils/retrieve_statement.py
@@ -140,7 +140,7 @@ def create_stmt_result(stmt_set, stored, language, format):
     if stmt_set:
         stmt_set = Statement.objects.filter(Q(statement_id__in=stmt_set) & Q(voided=False)).distinct()
         if format == 'exact':
-            stmt_result = '{"statements": [%s], "more": ""}' % ",".join([json.dumps(stmt.full_statement) for stmt in stmt_set.order_by(stored)])
+            stmt_result = '{"statements": [%s], "more": ""}' % ",".join([json.dumps(stmt.full_statement, sort_keys=False) for stmt in stmt_set.order_by(stored)])
         else:
             stmt_result['statements'] = [stmt.to_dict(language, format) for stmt in \
                 stmt_set.order_by(stored)]
@@ -193,7 +193,7 @@ def initial_cache_return(stmt_list, stored, limit, language, format, attachments
 
     # Return first page of results
     if format == 'exact':
-        result = '{"statements": [%s], "more": "%s"}' % (",".join([json.dumps(stmt.full_statement) for stmt in \
+        result = '{"statements": [%s], "more": "%s"}' % (",".join([json.dumps(stmt.full_statement, sort_keys=False) for stmt in \
                 Statement.objects.filter(id__in=stmt_pager.page(1).object_list).order_by(stored)]), MORE_ENDPOINT + cache_key)
     else:
         result['statements'] = [stmt.to_dict(language, format) for stmt in \
@@ -239,10 +239,10 @@ def build_statement_result(stmt_list, start_page, total_pages, limit, attachment
     current_page = start_page + 1
     # If that was the last page to display then just return the remaining stmts
     if current_page == total_pages:
-        stmt_pager = Paginator(stmt_list, limit)       
+        stmt_pager = Paginator(stmt_list, limit)
         # Return first page of results
         if format == 'exact':
-            result = '{"statements": [%s], "more": ""}' % ",".join([json.dumps(stmt.to_dict(language, format)) for stmt in \
+            result = '{"statements": [%s], "more": ""}' % ",".join([json.dumps(stmt.to_dict(language, format), sort_keys=False) for stmt in \
                 Statement.objects.filter(id__in=stmt_pager.page(current_page).object_list).order_by(stored)])
         else:
             result['statements'] = [stmt.to_dict(language, format) for stmt in \
@@ -264,7 +264,7 @@ def build_statement_result(stmt_list, start_page, total_pages, limit, attachment
         cache_key = create_cache_key(stmt_list)
         # Return first page of results
         if format == 'exact':
-            result = '{"statements": [%s], "more": "%s"}' % (",".join([json.dumps(stmt.to_dict(language, format)) for stmt in \
+            result = '{"statements": [%s], "more": "%s"}' % (",".join([json.dumps(stmt.to_dict(language, format), sort_keys=False) for stmt in \
                 Statement.objects.filter(id__in=stmt_pager.page(current_page).object_list).order_by(stored)]), MORE_ENDPOINT + cache_key)
         else:
             # Set result to have selected page of stmts and more endpoint


### PR DESCRIPTION
fixes #315 

returns statements so fields have same order for readability-main parts of statement remain untouched so returning in exact form should still be spec compliant