### PR TITLE
GCC is required for psycopg2

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ This version is stable, but only intended to support a small amount of users as 
 **Install Prerequisites**
 
     admin:~$ sudo apt-get install git fabric python-setuptools python-dev\
-        libxml2-dev libxslt1-dev
+        libxml2-dev libxslt1-dev gcc
     admin:~$ sudo easy_install pip
     admin:~$ sudo pip install virtualenv
 


### PR DESCRIPTION
GCC is required for psycopg2 to be successful. Adding this as 
an install prerequisite fixes that installation failure on a new server.