### PR TITLE
Feature/staticfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ federated-analytics.js
 *.conf
 lrs/celery.py
 *.ini
+staticfiles/*

--- a/adl_lrs/settings.py
+++ b/adl_lrs/settings.py
@@ -6,6 +6,7 @@ from ConfigParser import RawConfigParser
 # Root of LRS
 SETTINGS_DIR = dirname(abspath(__file__))
 PROJECT_ROOT = dirname(dirname(SETTINGS_DIR))
+BASE_DIR = path.join(SETTINGS_DIR, '..')
 
 config = RawConfigParser()
 config.read(SETTINGS_DIR+'/settings.ini')
@@ -86,7 +87,7 @@ MEDIA_URL = '/media/'
 # Don't put anything in this directory yourself; store your static files
 # in apps' "static/" subdirectories and in STATICFILES_DIRS.
 # Example: "/home/media/media.lawrence.com/static/"
-STATIC_ROOT = ''
+STATIC_ROOT = path.join(BASE_DIR, 'staticfiles')
 
 # URL prefix for static files.
 # Example: "http://media.lawrence.com/static/"

--- a/adl_lrs/templates/base.html
+++ b/adl_lrs/templates/base.html
@@ -1,3 +1,4 @@
+{% load static from staticfiles %}
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -5,18 +6,18 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="ADL's open LRS">
 
-    <link rel="shortcut icon" href="{{ STATIC_URL }}img/favicon.ico" />
-    <link rel="icon" href="{{ STATIC_URL }}img/favicon.ico" type="image/x-icon">
+    <link rel="shortcut icon" href="{% static "img/favicon.ico" %}" />
+    <link rel="icon" href="{% static "img/favicon.ico" %}" type="image/x-icon">
     
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/pure-min.css">
 
     <!--[if lte IE 8]>
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/grids-responsive-old-ie-min.css">
-      <link rel="stylesheet" href="{{ STATIC_URL }}css/marketing-old-ie.css">
+      <link rel="stylesheet" href="{% static "css/marketing-old-ie.css" %}">
     <![endif]-->
     <!--[if gt IE 8]><!-->
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/pure/0.6.0/grids-responsive-min.css">
-      <link rel="stylesheet" href="{{ STATIC_URL }}css/marketing.css">
+      <link rel="stylesheet" href="{% static "css/marketing.css" %}">
     <!--<![endif]-->
     {% block extra_css %}{% endblock extra_css %}
     <title>{% block title %}ADL LRS{% endblock title %}</title>

--- a/adl_lrs/templates/home.html
+++ b/adl_lrs/templates/home.html
@@ -1,4 +1,6 @@
 {% extends "base.html" %}
+{% load static from staticfiles %}
+
 {% block extra_css %}
 <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 <style>
@@ -165,7 +167,7 @@
       </div>
   </div>
   <div class="footer l-box is-center">
-      <img class="brand" height="35" width="55" src="{{ STATIC_URL }}img/adllogo.png" alt="experience api logo"/> Advanced Distributed Learning
+    <img class="brand" height="35" width="55" src="{% static "img/adllogo.png" %}" alt="experience api logo"/> Advanced Distributed Learning
       <p>This is an official website of the U.S. Government &copy; Advanced Distributed Learning</p>
   </div>
 </div>

--- a/adl_lrs/templates/me.html
+++ b/adl_lrs/templates/me.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
+{% load static from staticfiles %}
 {% load jsonify %}
+
 {% block extra_css %}
-<link rel="stylesheet" href="{{ STATIC_URL }}css/extra.css">
+<link rel="stylesheet" href="{% static "css/extra.css" %}">
 {% endblock extra_css %}
 {% block title %}{{user.username}}'s Account{% endblock title %}
 {% block heading %}{{user.username}}'s Account{% endblock heading %}
@@ -95,7 +97,7 @@
 {% endblock content %}
 {% block extra_js %}
 <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}scripts/extra-menu.js"></script>
+<script type="text/javascript" src="{% static "scripts/extra-menu.js" %}"></script>
 <script type="text/javascript">
     $(document).ready(function() {
         // These events stay inline so urls render correctly

--- a/adl_lrs/templates/my_activity_states.html
+++ b/adl_lrs/templates/my_activity_states.html
@@ -1,6 +1,8 @@
 {% extends "base.html" %}
+{% load static from staticfiles %}
+
 {% block extra_css %}
-<link rel="stylesheet" href="{{ STATIC_URL }}css/extra.css">
+<link rel="stylesheet" href="{% static "css/extra.css" %}">
 <style>
     pre {
         white-space: pre-wrap;       /* CSS 3 */
@@ -114,5 +116,5 @@
         });
     }
 </script>
-<script type="text/javascript" src="{{ STATIC_URL }}scripts/extra-data.js"></script>
+<script type="text/javascript" src="{% static "scripts/extra-data.js" %}"></script>
 {% endblock extra_js %}

--- a/adl_lrs/templates/my_hooks.html
+++ b/adl_lrs/templates/my_hooks.html
@@ -1,7 +1,8 @@
 {% extends "base.html" %}
+{% load static from staticfiles %}
 {% load jsonify %}
 {% block extra_css %}
-<link rel="stylesheet" href="{{ STATIC_URL }}css/extra.css">
+<link rel="stylesheet" href="{% static "css/extra.css" %}">
 {% endblock extra_css %}
 {% block title %}{{user.username}}'s Hooks{% endblock title %}
 {% block heading %}{{user.username}}'s Hooks{% endblock heading %}

--- a/adl_lrs/templates/my_statements.html
+++ b/adl_lrs/templates/my_statements.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
+{% load static from staticfiles %}
 {% load jsonify %}
+
 {% block extra_css %}
-<link rel="stylesheet" href="{{ STATIC_URL }}css/extra.css">
+<link rel="stylesheet" href="{% static "css/extra.css" %}">
 <style>
     pre {
         white-space: pre-wrap;       /* CSS 3 */
@@ -79,5 +81,5 @@
 {% endblock content %}
 {% block extra_js %}
 <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}scripts/extra-data.js"></script>
+<script type="text/javascript" src="{% static "scripts/extra-data.js" %}"></script>
 {% endblock extra_js %}

--- a/adl_lrs/templates/oauth_authorize_client.html
+++ b/adl_lrs/templates/oauth_authorize_client.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
+{% load static from staticfiles %}
+
 {% block title %}Application Access Approval{% endblock title %}
 {% block heading %}Application Access Approval{% endblock heading %}
 {% block extra_css %}
-<link rel="stylesheet" href="{{ STATIC_URL }}css/extra.css">
+<link rel="stylesheet" href="{% static "css/extra.css" %}">
 {% endblock extra_css %}
 {% block content %}
 <br>
@@ -54,5 +56,5 @@
         });
     });
 </script>
-<script type="text/javascript" src="{{ STATIC_URL }}scripts/extra-forms.js"></script>
+<script type="text/javascript" src="{% static "scripts/extra-forms.js" %}"></script>
 {% endblock extra_js %}

--- a/adl_lrs/templates/oauth_verifier_pin.html
+++ b/adl_lrs/templates/oauth_verifier_pin.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
+{% load static from staticfiles %}
+
 {% block title %}ADL LRS Client Allow Access{% endblock title %}
 {% block heading %}ADL LRS Client Allow Access{% endblock heading %}
 {% block extra_css %}
-<link rel="stylesheet" href="{{ STATIC_URL }}css/extra.css">
+<link rel="stylesheet" href="{% static "css/extra.css" %}">
 {% endblock extra_css %}
 {% block content %}
 <br>

--- a/adl_lrs/templates/regclient.html
+++ b/adl_lrs/templates/regclient.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
+{% load static from staticfiles %}
+
 {% block title %}ADL LRS Client Registration{% endblock title %}
 {% block heading %}ADL LRS Client Registration{% endblock heading %}
 {% block extra_css %}
-<link rel="stylesheet" href="{{ STATIC_URL }}css/extra.css">
+<link rel="stylesheet" href="{% static "css/extra.css" %}">
 {% endblock extra_css %}
 {% block content %}
 <br>
@@ -54,5 +56,5 @@
 {% endblock content %}
 {% block extra_js %}
 <script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
-<script type="text/javascript" src="{{ STATIC_URL }}scripts/extra-forms.js"></script>
+<script type="text/javascript" src="{% static "scripts/extra-forms.js" %}"></script>
 {% endblock extra_js %}

--- a/adl_lrs/templates/register.html
+++ b/adl_lrs/templates/register.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
+{% load static from staticfiles %}
+
 {% block title %}ADL LRS Registration{% endblock title %}
 {% block heading %}ADL LRS Registration{% endblock heading %}
 {% block extra_css %}
-<link rel="stylesheet" href="{{ STATIC_URL }}css/extra.css">
+<link rel="stylesheet" href="{% static "css/extra.css" %}">
 {% endblock extra_css %}
 {% block content %}
 <br>

--- a/adl_lrs/templates/registration/login.html
+++ b/adl_lrs/templates/registration/login.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
+{% load static from staticfiles %}
+
 {% block title %}ADL LRS Login{% endblock title %}
 {% block heading %}ADL LRS Login{% endblock heading %}
 {% block extra_css %}
-<link rel="stylesheet" href="{{ STATIC_URL }}css/extra.css">
+<link rel="stylesheet" href="{% static "css/extra.css" %}">
 {% endblock extra_css %}
 {% block content %}
 <br>

--- a/adl_lrs/templates/registration/password_reset_complete.html
+++ b/adl_lrs/templates/registration/password_reset_complete.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
+{% load static from staticfiles %}
+
 {% block title %}ADL LRS Reset Complete{% endblock title %}
 {% block heading %}ADL LRS Reset Complete{% endblock heading %}
 {% block extra_css %}
-<link rel="stylesheet" href="{{ STATIC_URL }}css/extra.css">
+<link rel="stylesheet" href="{% static "css/extra.css" %}">
 {% endblock extra_css %}
 {% block content %}
 <br>

--- a/adl_lrs/templates/registration/password_reset_confirm.html
+++ b/adl_lrs/templates/registration/password_reset_confirm.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
+{% load static from staticfiles %}
+
 {% block title %}ADL LRS Reset Confirmation{% endblock title %}
 {% block heading %}ADL LRS Reset Confirmation{% endblock heading %}
 {% block extra_css %}
-<link rel="stylesheet" href="{{ STATIC_URL }}css/extra.css">
+<link rel="stylesheet" href="{% static "css/extra.css" %}">
 {% endblock extra_css %}
 {% block content %}
 <br>

--- a/adl_lrs/templates/registration/password_reset_done.html
+++ b/adl_lrs/templates/registration/password_reset_done.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
+{% load static from staticfiles %}
+
 {% block title %}ADL LRS Reset Successful{% endblock title %}
 {% block heading %}ADL LRS Reset Successful{% endblock heading %}
 {% block extra_css %}
-<link rel="stylesheet" href="{{ STATIC_URL }}css/extra.css">
+<link rel="stylesheet" href="{% static "css/extra.css" %}">
 {% endblock extra_css %}
 {% block content %}
 <br>

--- a/adl_lrs/templates/registration/password_reset_form.html
+++ b/adl_lrs/templates/registration/password_reset_form.html
@@ -1,8 +1,10 @@
 {% extends "base.html" %}
+{% load static from staticfiles %}
+
 {% block title %}ADL LRS Reset{% endblock title %}
 {% block heading %}ADL LRS Reset{% endblock heading %}
 {% block extra_css %}
-<link rel="stylesheet" href="{{ STATIC_URL }}css/extra.css">
+<link rel="stylesheet" href="{% static "css/extra.css" %}>
 {% endblock extra_css %}
 {% block content %}
 <br>

--- a/adl_lrs/templates/validator.html
+++ b/adl_lrs/templates/validator.html
@@ -1,7 +1,9 @@
 {% extends "base.html" %}
+{% load static from staticfiles %}
+
 {% block title %}ADL LRS xAPI Statement Validator{% endblock title %}
 {% block extra_css %}
-<link rel="stylesheet" href="{{ STATIC_URL }}css/extra.css">
+<link rel="stylesheet" href="{% static "css/extra.css" %}">
 {% endblock extra_css %}
 {% block content %}
 <br>


### PR DESCRIPTION
This branch updates the project to explicitly define the STATIC_ROOT, which is project root level directory called 'staticfiles'. It also updates the templates to make use of the 'static' template tag instead of manually prepending {{STATIC_URL}} to static assets.

These changes apply some best practices and should also simplify the wiki's nginx conf. The multiple /static/ blocks should no longer be needed. 'collectstatic' should now bring all those relevant assets to the 'staticfiles' directory. So, you can now just have a single /static/ block in the nginx config.