### PR TITLE
Adding Last-Modified Headers

### DIFF
--- a/lrs/models.py
+++ b/lrs/models.py
@@ -762,8 +762,7 @@ class StatementAttachment(models.Model):
 
 class ActivityState(models.Model):
     state_id = models.CharField(max_length=MAX_URL_LENGTH)
-    updated = models.DateTimeField(
-        auto_now_add=True, blank=True, db_index=True)
+    updated = models.DateTimeField(auto_now_add=True, blank=True, db_index=True)
     activity_id = models.CharField(max_length=MAX_URL_LENGTH, db_index=True)
     registration_id = models.CharField(max_length=40, db_index=True)
     content_type = models.CharField(max_length=255, blank=True)

--- a/lrs/tests/test_Statement.py
+++ b/lrs/tests/test_Statement.py
@@ -584,6 +584,29 @@ class StatementTests(TestCase):
         self.assertEqual(list(lang_map2.keys())[0], "en-GB")
         self.assertEqual(list(lang_map2.values())[0], "failed")
 
+    #The LRS shall include a "last modified" header which matches the "stored" Timestamp of the statment
+    def test_last_modified_header(self):
+        self.bunchostmts()
+        getResponse = self.client.get(reverse(
+            'lrs:statements'), X_Experience_API_Version=settings.XAPI_VERSION, Authorization=self.auth)
+        self.assertEqual(response.status_code, 200)
+        #assert it has/included correct header
+        self.assertIn('Last-Modified', getResponse._headers)
+        #And that it equals the stored timestamp
+        lastModified = getResponse._headers('Last-Modified')
+        timeStamp = self.stored
+        self.assertEqual(lastModified, timestamp)
+
+   
+self.bunchostmts()
+        getResponse = self.client.get(reverse(
+            'lrs:statements'), X_Experience_API_Version=settings.XAPI_VERSION, Authorization=self.auth)
+        self.assertEqual(getResponse.status_code, 200)
+        jsn = json.loads(getResponse.content)
+        self.assertEqual(len(jsn["statements"]), 11)
+        self.assertIn('content-length', getResponse._headers)
+
+
     def test_put(self):
         guid = uuid.uuid4()
 

--- a/lrs/utils/req_process.py
+++ b/lrs/utils/req_process.py
@@ -210,6 +210,10 @@ def statements_more_get(req_dict):
         else:
             resp = HttpResponse(json.dumps(stmt_result),
                                 content_type=mime_type, status=200)
+##Create the response header
+
+##last modified is in humane readable info like dddec 25, so there is a conversion needed
+#for now iso format andresolved later , update to return statment result
     resp['Content-Length'] = str(content_length)
 
     return resp
@@ -230,13 +234,19 @@ def statements_get(req_dict):
                                 status=200)
         else:
             stmt_result = json.dumps(stmt_dict, sort_keys=False)
+
             resp = HttpResponse(
                 stmt_result, content_type=mime_type, status=200)
+            
+            resp['Last-Modified'] = st['stored']
+
             content_length = len(stmt_result)
     # Complex GET
     else:
         resp, content_length = process_complex_get(req_dict)
-    resp['Content-Length'] = str(content_length)
+        resp['Content-Length'] = str(content_length)
+        
+        resp['Last-Modified'] = st['stored']
 
     return resp
 

--- a/lrs/utils/req_process.py
+++ b/lrs/utils/req_process.py
@@ -368,6 +368,7 @@ def activity_state_get(req_dict):
         # state id means we want only 1 item
         if state_id:
             resource = actstate.get_state(activity_id, registration, state_id)
+            #MB Resource is a model of AgentProfile, it has an 'updated' property
             if resource.state:
                 response = HttpResponse(
                     resource.state.read(), content_type=resource.content_type)
@@ -375,12 +376,18 @@ def activity_state_get(req_dict):
                 response = HttpResponse(
                     resource.json_state, content_type=resource.content_type)
             response['ETag'] = '"%s"' % resource.etag
+
+            #MB place our header (updated is saved as a datetime field, so it doesn't need to be pulled from isoformat)
+            response['Last-Modified'] = resource.updated.strftime("%a, %d-%b-%Y %H:%M:%S %Z")
+        
         # no state id means we want an array of state ids
         else:
             since = req_dict['params'].get('since', None)
             resource = actstate.get_state_ids(activity_id, registration, since)
             response = JsonResponse([k for k in resource], safe=False)
-
+            #MB place our header (updated is saved as a datetime field, so it doesn't need to be pulled from isoformat)
+            response['Last-Modified'] = resource.updated.strftime("%a, %d-%b-%Y %H:%M:%S %Z")
+            
     return response
 
 

--- a/lrs/utils/req_process.py
+++ b/lrs/utils/req_process.py
@@ -385,9 +385,7 @@ def activity_state_get(req_dict):
             since = req_dict['params'].get('since', None)
             resource = actstate.get_state_ids(activity_id, registration, since)
             response = JsonResponse([k for k in resource], safe=False)
-            #MB place our header (updated is saved as a datetime field, so it doesn't need to be pulled from isoformat)
-            response['Last-Modified'] = resource.updated.strftime("%a, %d-%b-%Y %H:%M:%S %Z")
-            
+
     return response
 
 
@@ -442,6 +440,9 @@ def activity_profile_get(req_dict):
             response = HttpResponse(
                 resource.json_profile, content_type=resource.content_type)
         response['ETag'] = '"%s"' % resource.etag
+
+        #MB place our header (updated is saved as a datetime field, so it doesn't need to be pulled from isoformat)
+        response['Last-Modified'] = resource.updated.strftime("%a, %d-%b-%Y %H:%M:%S %Z")
         return response
 
     # Return IDs of profiles stored since profileId was not submitted
@@ -514,6 +515,8 @@ def agent_profile_get(req_dict):
                 response = HttpResponse(
                     resource.json_profile, content_type=resource.content_type)
             response['ETag'] = '"%s"' % resource.etag
+            #place our header (updated is saved as a datetime field, so it doesn't need to be pulled from isoformat)
+            response['Last-Modified'] = resource.updated.strftime("%a, %d-%b-%Y %H:%M:%S %Z")
             return response
 
         since = req_dict['params'].get(


### PR DESCRIPTION
Adds `Last-Modified` headers to GET responses for multiple statements and single document resources, required by xAPI 2.0. 