### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM cgr.dev/chainguard/python:latest-dev
 
 ENV UWSGI_PIP_VERSION 2.0.20
 


### PR DESCRIPTION
Updated the Docker Python container image. Instead, we recommend using the latest Chainguard Python image, which is free to use, hardened daily, and actively maintained to eliminate CVEs by patching both direct and transitive dependencies.

If python:latest (currently 3.13) meets your requirements, the transition should be straightforward—and will significantly reduce software supply chain risk.

See the difference: [https://images.chainguard.dev/directory/image/python/compare](https://images.chainguard.dev/directory/image/python/compare)
![Screenshot 2025-05-20 at 10 17 17 AM](https://github.com/user-attachments/assets/c75b3b51-2bde-4e05-aca9-f2f6bdccd65b)


**Grype container image vulnerability scan results from docker python image**  `python:3.9`
chainguard ~ grype python:3.9
 ✔ Vulnerability DB                [no update available]  
 ✔ Pulled image                    
 ✔ Loaded image                                                                                                          python:3.9
 ✔ Parsed image                                             sha256:776bdc0c22561e8b03f93b2acb5fabe4bd26fabe2898fc89861abdc43c201584
 ✔ Cataloged contents                                              f00819800cd24bc59869eb7308bcd8246ce92fa98f8ce37f122c1e9478c2ea3c
   ├── ✔ Packages                        [440 packages]  
   ├── ✔ File digests                    [20,098 files]  
   ├── ✔ File metadata                   [20,098 locations]  
   └── ✔ Executables                     [1,428 executables]  
   
 **✔ Scanned for vulnerabilities     [808 vulnerability matches]  
   ├── by severity: 6 critical, 108 high, 346 medium, 71 low, 626 negligible (225 unknown)
   └── by status:   7 fixed, 1375 not-fixed, 574 ignored** 
NAME                          INSTALLED                     FIXED-IN                  TYPE    VULNERABILITY        SEVERITY   
apt                           2.6.1                                                   deb     CVE-2011-3374        Negligible  
...
patch                         2.7.6-7                                                 deb     CVE-2010-4651        Negligible  
perl                          5.36.0-7+deb12u2              (won't fix)               deb     CVE-2023-31484       High        
perl                          5.36.0-7+deb12u2                                        deb     CVE-2023-31486       Negligible  
perl                          5.36.0-7+deb12u2                                        deb     CVE-2011-4116        Negligible  
perl-base                     5.36.0-7+deb12u2              (won't fix)               deb     CVE-2023-31484       High        
perl-base                     5.36.0-7+deb12u2                                        deb     CVE-2023-31486       Negligible  
perl-base                     5.36.0-7+deb12u2                                        deb     CVE-2011-4116        Negligible  
perl-modules-5.36             5.36.0-7+deb12u2              (won't fix)               deb     CVE-2023-31484       High        
perl-modules-5.36             5.36.0-7+deb12u2                                        deb     CVE-2023-31486       Negligible  
perl-modules-5.36             5.36.0-7+deb12u2                                        deb     CVE-2011-4116        Negligible  
pip                           23.0.1                        23.3                      python  GHSA-mq26-g339-26xf  Medium      
procps                        2:4.0.2-3                     (won't fix)               deb     CVE-2023-4016        Low         
python                        3.9.22                                                  binary  CVE-2023-36632       High        
python                        3.9.22                        3.14.0b1                  binary  CVE-2025-4516        Medium      
python                        3.9.22                        3.10.0b1                  binary  CVE-2024-5642        Medium      
python                        3.9.22                        3.11.9, 3.12.3, 3.13.0a5  binary  CVE-2025-1795        Low         
python                        3.9.22                        3.14.0                    binary  CVE-2024-3220        Low         
python3.11                    3.11.2-6+deb12u5                                        deb     CVE-2025-4516        Medium      
python3.11                    3.11.2-6+deb12u5              (won't fix)               deb     CVE-2025-0938        Medium      
python3.11                    3.11.2-6+deb12u5              (won't fix)               deb     CVE-2025-1795        Low         
python3.11-minimal            3.11.2-6+deb12u5                                        deb     CVE-2025-4516        Medium      
python3.11-minimal            3.11.2-6+deb12u5              (won't fix)               deb     CVE-2025-0938        Medium      
python3.11-minimal            3.11.2-6+deb12u5              (won't fix)               deb     CVE-2025-1795        Low         
setuptools                    58.1.0                        65.5.1                    python  GHSA-r9hx-vwmv-q579  High        
setuptools                    58.1.0                        70.0.0                    python  GHSA-cx63-2mw6-8hw5  High        
tar                           1.34+dfsg-1.2+deb12u1                                   deb     CVE-2005-2541        Negligible  
tcl8.6                        8.6.13+dfsg-2                                           deb     CVE-2021-35331       Negligible  
tcl8.6-dev                    8.6.13+dfsg-2                                           deb     CVE-2021-35331       Negligible  
unzip                         6.0-28                                                  deb     CVE-2021-4217        Negligible  
util-linux                    2.38.1-5+deb12u3                                        deb     CVE-2022-0563        Negligible  
util-linux-extra              2.38.1-5+deb12u3                                        deb     CVE-2022-0563        Negligible  
uuid-dev                      2.38.1-5+deb12u3                                        deb     CVE-2022-0563        Negligible  
wget                          1.21.3-1+deb12u1              (won't fix)               deb     CVE-2024-10524       Medium      
wget                          1.21.3-1+deb12u1              (won't fix)               deb     CVE-2021-31879       Medium      
zlib1g                        1:1.2.13.dfsg-1               (won't fix)               deb     CVE-2023-45853       Critical    
zlib1g-dev                    1:1.2.13.dfsg-1               (won't fix)               deb     CVE-2023-45853       Critical


**Grype container image vulnerability scan results from Chainguard python image**  `python:latest-dev`
chainguard ~ grype cgr.dev/chainguard/python:latest-dev
 ⠴ Pulling image                   
✔ Pulled image                    
 ✔ Loaded image                                                                                cgr.dev/chainguard/python:latest-dev
 ✔ Parsed image                                             sha256:0cb0f9c168cfdd24921e39a5d72a2b8167c689f19bc19641570b5c1ced2b77db
 ✔ Cataloged contents                                              a5903b3ae59524deb06d46403e17fdf8fecfbc019bfd8bbdffba22d8fa5fddd2
   ├── ✔ Packages                        [898 packages]  
   ├── ✔ File digests                    [7,264 files]  
   ├── ✔ File metadata                   [7,264 locations]  
   └── ✔ Executables                     [289 executables]  
 
 **✔ Scanned for vulnerabilities     [3 vulnerability matches]  
   ├── by severity: 0 critical, 0 high, 1 medium, 2 low, 0 negligible
   └── by status:   0 fixed, 3 not-fixed, 0 ignored** 
NAME         INSTALLED   FIXED-IN  TYPE  VULNERABILITY   SEVERITY 
busybox      1.37.0-r40            apk   CVE-2025-46394  Low       
busybox      1.37.0-r40            apk   CVE-2024-58251  Low       
python-3.13  3.13.3-r0             apk   CVE-2025-4516   Medium